### PR TITLE
Tweak pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "watch": "tsc -w --preserveWatchOutput"
+    "ts-build": "tsc",
+    "ts-watch": "tsc -w --preserveWatchOutput"
   },
   "keywords": [],
   "author": "Kevin M Ashton",

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -7,8 +7,7 @@ export const defaultQueryLimit = 1000;
 export function generateQueryRef<ItemModel>(
   queryRequest: SimpleQuery<ItemModel>,
   collection: string,
-  fireStore: firebase.firestore.Firestore,
-  startAfter?: any
+  fireStore: firebase.firestore.Firestore
 ): firebase.firestore.CollectionReference {
   let query = fireStore.collection(collection);
 
@@ -34,24 +33,25 @@ export function generateQueryRef<ItemModel>(
     }
   }
 
-  // If an _internalStartAfterDocId exists then we will automaticaly append startAfter so no need to add this
-  if (!queryRequest._internalStartAfterDocId) {
-    if (queryRequest.startAt) {
-      query = query.startAt(...queryRequest.startAt) as any;
-    }
+  if (queryRequest.startAt) {
+    query = query.startAt(...queryRequest.startAt) as any;
+  }
+
+  if (queryRequest.startAfter) {
+    query = query.startAfter(...queryRequest.startAfter) as any;
   }
 
   if (queryRequest.endAt) {
     query = query.endAt(...queryRequest.endAt) as any;
   }
 
+  if (queryRequest.endBefore) {
+    query = query.endBefore(...queryRequest.endBefore) as any;
+  }
+
   // Lock it to something to prevent massive batches but also to make it easier to detect if we need to paginate
   let limit = queryRequest.limit === undefined ? defaultQueryLimit : queryRequest.limit;
   query = query.limit(limit) as any;
-
-  if (startAfter) {
-    query.startAfter(startAfter);
-  }
 
   return query;
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,14 +1,20 @@
 type WhereFilter<ItemModel> = OptionalQuery<ItemModel>;
 type WhereFilterOp = "<" | "<=" | "==" | ">=" | ">" | "array-contains";
 type OrderByDirection = "desc" | "asc";
-type startEndAtTypes = string | number;
+export type startEndAtTypes =
+  | string
+  | number
+  | firebase.firestore.DocumentSnapshot
+  | firebase.firestore.QueryDocumentSnapshot;
 
 export interface SimpleQuery<ItemModel> {
   limit?: number;
   where?: WhereFilter<ItemModel>[];
   orderBy?: { pathObj: OptionalFlex<ItemModel>; dir?: OrderByDirection }[];
   startAt?: startEndAtTypes[];
+  startAfter?: startEndAtTypes[];
   endAt?: startEndAtTypes[];
+  endBefore?: startEndAtTypes[];
   _internalStartAfterDocId?: any; // Used for pagination. If defined then we ignore startAt
 }
 


### PR DESCRIPTION
Couple of changes:

1. Add `rawDocItems` to query result sets to expose the raw document snapshots
2. Amplify `startEndAtTypes` to include a document snapshot
3. Add `endBefore` and `startAfter` methods
4. Tweak how the subscription meta data is stringified since queries can now include document snapshots which have circular structures. 